### PR TITLE
Add pelican-readtime support

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -9,14 +9,7 @@
                 <a href="{{ SITEURL }}/{{ article.category.url }}"><img src="{{ MEDIUS_CATEGORIES.get(article.category|string).thumbnail }} " class="post-avatar" alt="{{ article.category|striptags }}"></a>
             </div>
             {% endif %}
-            <div class="pure-u-3-4 meta-data">
-                <a href="{{ SITEURL }}/{{ article.category.url }}" class="category">{{ article.category }}</a><br />
-
-                {% for author in article.authors %}
-                <a class="author" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
-                {% endfor %}
-                &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
-            </div>
+            {% include "includes/post_metadata.html" %}
         </div>
     </div>
 

--- a/templates/category.html
+++ b/templates/category.html
@@ -47,7 +47,10 @@
                    {% endif %}
                    <div class="pure-u-3-4 meta-data">
                        <a href="{{ SITEURL }}/{{ author.url }}" class="category">{{ author }}</a><br />
-                       &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                       <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                       {% if article.readtime_minutes %}
+                       &mdash; {{ article.readtime_minutes }} min read
+                       {% endif %}
                    </div>
                </div>
                {% endfor %}
@@ -82,7 +85,10 @@
                 {% endif %}
                 <div class="pure-u-3-4 meta-data">
                     <a href="{{ SITEURL }}/{{ author.url }}" class="category">{{ author }}</a><br />
-                    &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                    <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                    {% if article.readtime_minutes %}
+                    &mdash; {{ article.readtime_minutes }} min read
+                    {% endif %}
                 </div>
             </div>
             {% endfor %}
@@ -119,7 +125,10 @@
                 {% endif %}
                 <div class="pure-u-3-4 meta-data">
                     <a href="{{ SITEURL }}/{{ author.url }}" class="category">{{ author }}</a><br />
-                    &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                    <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+                    {% if article.readtime_minutes %}
+                    &mdash; {{ article.readtime_minutes }} min read
+                    {% endif %}
                 </div>
             </div>
             {% endfor %}

--- a/templates/includes/post_metadata.html
+++ b/templates/includes/post_metadata.html
@@ -1,0 +1,11 @@
+<div class="pure-u-3-4 meta-data">
+    <a href="{{ SITEURL }}/{{ article.category.url }}" class="category">{{ article.category }}</a><br />
+
+    {% for author in article.authors %}
+    <a class="author" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
+    {% endfor %}
+    &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
+    {% if article.readtime_minutes %}
+    &mdash; {{ article.readtime_minutes }} min read
+    {% endif %}
+</div>

--- a/templates/includes/posts.html
+++ b/templates/includes/posts.html
@@ -8,14 +8,7 @@
         </div>
         {% endif %}
 
-        <div class="pure-u-3-4 meta-data">
-            <a href="{{ SITEURL }}/{{ article.category.url }}" class="category">{{ article.category }}</a><br />
-
-            {% for author in article.authors %}
-            <a class="author" href="{{ SITEURL }}/{{ author.url }}">{{ author }}</a>
-            {% endfor %}
-            &mdash; <abbr title="{{ article.date.isoformat() }}">{{ article.locale_date }}</abbr>
-        </div>
+        {% include "includes/post_metadata.html" %}
     </div>
     {% if article.thumbnail %}
     <a href="{{ SITEURL }}/{{ article.url }}"><img src="{{ article.thumbnail }}" alt="{{ article.title|striptags }}" class="post-image"/></a>


### PR DESCRIPTION
[JenkinsDev/pelican-readtime](https://github.com/JenkinsDev/pelican-readtime) is a nice project that add the estimated readtime to articles context. I added it to [my blog](http://blog.tomgurion.me) recently, and thought that it might be a good addition to medius.
